### PR TITLE
Fixing (back) transition on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 > Apr 4, 2017
 
 * :bug: **Bugfix** Using setTimeout(fn, 0) to ensure correct pixelheight is set before transition (back) starts. This ensures we are not transitioning back from `auto`. Ref: http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
+* :bug: **Bugfix** Checking if content is set before accessing content in requestAnimationFrame callback. This fixes a bug where `this.content` was null initially when navigating back to a page using react-css-collapse you had been to before.
 
 # 2.0.1
 > Apr 3, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 2.0.2
 > Apr 4, 2017
 
-* :bug: **Bugfix** Using setTimeout(fn, 0) to ensure correct pixelheight is set before transition (back) starts. This ensures we are not transitioning back from `auto`
+* :bug: **Bugfix** Using setTimeout(fn, 0) to ensure correct pixelheight is set before transition (back) starts. This ensures we are not transitioning back from `auto`. Ref: http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
 
 # 2.0.1
 > Apr 3, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.0.2
+> Apr 4, 2017
+
+* :bug: **Bugfix** Using setTimeout(fn, 0) to ensure correct pixelheight is set before transition (back) starts. This ensures we are not transitioning back from `auto`
+
 # 2.0.1
 > Apr 3, 2017
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "authors": [
     "Torleif Halseth",
     "Håkon Nilsen",
-    "Eirik Årdal"
+    "Eirik Årdal",
+    "Daniel Selvik",
   ],
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "Torleif Halseth",
     "Håkon Nilsen",
     "Eirik Årdal",
-    "Daniel Selvik",
+    "Daniel Selvik"
   ],
   "license": "MIT",
   "repository": {

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -48,7 +48,7 @@ class Collapse extends Component {
     return new Promise(
       (resolve) => {
         this.content.style.height = `${this.content.scrollHeight}px`;
-        resolve(this.content.scrollHeight);
+        resolve();
       },
     );
   }

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -17,27 +17,42 @@ class Collapse extends Component {
     }
   }
   componentWillReceiveProps(nextProps) {
-    const height = this.content.scrollHeight;
+    const element = this.content;
+    const height = element.scrollHeight;
     // expand
     if (!this.props.isOpen && nextProps.isOpen) {
       // have the element transition to the height of its inner content
-      this.content.style.height = `${height}px`;
+      element.style.height = `${height}px`;
     }
     // collapse
     if (this.props.isOpen && !nextProps.isOpen) {
-      const element = this.content;
       // explicitly set the element's height to its current pixel height, so we
       // aren't transitioning out of 'auto'
       element.style.height = `${height}px`;
 
-      // on the next frame (as soon as the previous style change has taken effect),
-      // have the element transition to height: 0
-      window.requestAnimationFrame(() => {
-        element.style.height = '0px';
-        element.style.overflow = 'hidden';
-      });
+      this.setHeightToCurrentPixelHeight()
+        .then(() => {
+          // on the next frame (as soon as the previous style change has taken effect),
+          // have the element transition to height: 0
+          setTimeout(() => {
+            window.requestAnimationFrame(() => {
+              element.style.height = '0px';
+              element.style.overflow = 'hidden';
+            });
+          }, 0);
+        });
     }
   }
+
+  setHeightToCurrentPixelHeight() {
+    return new Promise(
+      (resolve) => {
+        this.content.style.height = `${this.content.scrollHeight}px`;
+        resolve(this.content.scrollHeight);
+      },
+    );
+  }
+
   render() {
     return (
       <div

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -4,16 +4,7 @@ import util from '../util';
 class Collapse extends Component {
   componentDidMount() {
     if (this.props.isOpen) {
-      // temporarily disable css transition
-      const transition = this.content.style.transition;
-      this.content.style.transition = '';
-
-      // on the next frame (as soon as removing transition has taken effect)
-      util.requestAnimationFrame(() => {
-        // have the element set to the height of its inner content without transition
-        this.content.style.height = `${this.content.scrollHeight}px`;
-        this.content.style.transition = transition;
-      });
+      this.content.style.height = 'auto';
     }
   }
   componentWillReceiveProps(nextProps) {
@@ -29,7 +20,7 @@ class Collapse extends Component {
       // explicitly set the element's height to its current pixel height, so we
       // aren't transitioning out of 'auto'
       element.style.height = `${height}px`;
-      window.requestAnimationFrame(() => {
+      util.requestAnimationFrame(() => {
         // "pausing" the JavaScript execution to let the rendering threads catch up
         // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
         setTimeout(() => {

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -29,28 +29,13 @@ class Collapse extends Component {
       // explicitly set the element's height to its current pixel height, so we
       // aren't transitioning out of 'auto'
       element.style.height = `${height}px`;
-
-      this.setHeightToCurrentPixelHeight()
-        .then(() => {
-          // on the next frame (as soon as the previous style change has taken effect),
-          // have the element transition to height: 0
-          setTimeout(() => {
-            window.requestAnimationFrame(() => {
-              element.style.height = '0px';
-              element.style.overflow = 'hidden';
-            });
-          }, 0);
-        });
+      window.requestAnimationFrame(() => {
+        setTimeout(() => {
+          element.style.height = '0px';
+          element.style.overflow = 'hidden';
+        }, 0);
+      });
     }
-  }
-
-  setHeightToCurrentPixelHeight() {
-    return new Promise(
-      (resolve) => {
-        this.content.style.height = `${this.content.scrollHeight}px`;
-        resolve();
-      },
-    );
   }
 
   render() {

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -31,6 +31,7 @@ class Collapse extends Component {
       element.style.height = `${height}px`;
       window.requestAnimationFrame(() => {
         // "pausing" the JavaScript execution to let the rendering threads catch up
+        // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
         setTimeout(() => {
           element.style.height = '0px';
           element.style.overflow = 'hidden';

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -4,32 +4,32 @@ import util from '../util';
 class Collapse extends Component {
   componentDidMount() {
     if (this.props.isOpen) {
-      this.setContentProperty('height', 'auto');
+      this.setContentStyleProperty('height', 'auto');
     }
   }
   componentWillReceiveProps(nextProps) {
     // expand
     if (!this.props.isOpen && nextProps.isOpen) {
       // have the element transition to the height of its inner content
-      this.setContentProperty('height', `${this.content.scrollHeight}px`);
+      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
     }
     // collapse
     if (this.props.isOpen && !nextProps.isOpen) {
       // explicitly set the element's height to its current pixel height, so we
       // aren't transitioning out of 'auto'
-      this.setContentProperty('height', `${this.content.scrollHeight}px`);
+      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
       util.requestAnimationFrame(() => {
         // "pausing" the JavaScript execution to let the rendering threads catch up
         // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
         setTimeout(() => {
-          this.setContentProperty('height', '0px');
-          this.setContentProperty('overflow', 'hidden');
+          this.setContentStyleProperty('height', '0px');
+          this.setContentStyleProperty('overflow', 'hidden');
         }, 0);
       });
     }
   }
 
-  setContentProperty(property, value) {
+  setContentStyleProperty(property, value) {
     this.content.style[property] = value;
   }
 
@@ -45,8 +45,8 @@ class Collapse extends Component {
         className={this.props.className}
         onTransitionEnd={() => {
           if (this.props.isOpen) {
-            this.setContentProperty('height', 'auto');
-            this.setContentProperty('overflow', 'visible');
+            this.setContentStyleProperty('height', 'auto');
+            this.setContentStyleProperty('overflow', 'visible');
           }
         }}
       >

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -4,31 +4,33 @@ import util from '../util';
 class Collapse extends Component {
   componentDidMount() {
     if (this.props.isOpen) {
-      this.content.style.height = 'auto';
+      this.setContentProperty('height', 'auto');
     }
   }
   componentWillReceiveProps(nextProps) {
-    const element = this.content;
-    const height = element.scrollHeight;
     // expand
     if (!this.props.isOpen && nextProps.isOpen) {
       // have the element transition to the height of its inner content
-      element.style.height = `${height}px`;
+      this.setContentProperty('height', `${this.content.scrollHeight}px`);
     }
     // collapse
     if (this.props.isOpen && !nextProps.isOpen) {
       // explicitly set the element's height to its current pixel height, so we
       // aren't transitioning out of 'auto'
-      element.style.height = `${height}px`;
+      this.setContentProperty('height', `${this.content.scrollHeight}px`);
       util.requestAnimationFrame(() => {
         // "pausing" the JavaScript execution to let the rendering threads catch up
         // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
         setTimeout(() => {
-          element.style.height = '0px';
-          element.style.overflow = 'hidden';
+          this.setContentProperty('height', '0px');
+          this.setContentProperty('overflow', 'hidden');
         }, 0);
       });
     }
+  }
+
+  setContentProperty(property, value) {
+    this.content.style[property] = value;
   }
 
   render() {
@@ -43,8 +45,8 @@ class Collapse extends Component {
         className={this.props.className}
         onTransitionEnd={() => {
           if (this.props.isOpen) {
-            this.content.style.height = 'auto';
-            this.content.style.overflow = 'visible';
+            this.setContentProperty('height', 'auto');
+            this.setContentProperty('overflow', 'visible');
           }
         }}
       >

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -21,10 +21,12 @@ class Collapse extends Component {
       util.requestAnimationFrame(() => {
         // "pausing" the JavaScript execution to let the rendering threads catch up
         // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
-        setTimeout(() => {
-          this.setContentStyleProperty('height', '0px');
-          this.setContentStyleProperty('overflow', 'hidden');
-        }, 0);
+        if (this.content) {
+          setTimeout(() => {
+            this.setContentStyleProperty('height', '0px');
+            this.setContentStyleProperty('overflow', 'hidden');
+          }, 0);
+        }
       });
     }
   }

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -3,31 +3,31 @@ import util from '../util';
 
 class Collapse extends Component {
   componentDidMount() {
-    if (this.props.isOpen) {
+    if (this.props.isOpen && this.content) {
       this.setContentStyleProperty('height', 'auto');
     }
   }
   componentWillReceiveProps(nextProps) {
-    // expand
-    if (!this.props.isOpen && nextProps.isOpen) {
-      // have the element transition to the height of its inner content
-      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
-    }
-    // collapse
-    if (this.props.isOpen && !nextProps.isOpen) {
-      // explicitly set the element's height to its current pixel height, so we
-      // aren't transitioning out of 'auto'
-      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
-      util.requestAnimationFrame(() => {
-        // "pausing" the JavaScript execution to let the rendering threads catch up
-        // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
-        if (this.content) {
+    if (this.content) {
+      // expand
+      if (!this.props.isOpen && nextProps.isOpen) {
+        // have the element transition to the height of its inner content
+        this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
+      }
+      // collapse
+      if (this.props.isOpen && !nextProps.isOpen) {
+        // explicitly set the element's height to its current pixel height, so we
+        // aren't transitioning out of 'auto'
+        this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
+        util.requestAnimationFrame(() => {
+          // "pausing" the JavaScript execution to let the rendering threads catch up
+          // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
           setTimeout(() => {
             this.setContentStyleProperty('height', '0px');
             this.setContentStyleProperty('overflow', 'hidden');
           }, 0);
-        }
-      });
+        });
+      }
     }
   }
 

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -30,6 +30,7 @@ class Collapse extends Component {
       // aren't transitioning out of 'auto'
       element.style.height = `${height}px`;
       window.requestAnimationFrame(() => {
+        // "pausing" the JavaScript execution to let the rendering threads catch up
         setTimeout(() => {
           element.style.height = '0px';
           element.style.overflow = 'hidden';

--- a/test/components/Collapse.spec.js
+++ b/test/components/Collapse.spec.js
@@ -36,7 +36,7 @@ describe('<Collapse />', () => {
         mount(<Collapse />).find('div').props().style.height,
       ).to.equal('0px');
     });
-    it('inner block should have height: auto when open', () => {
+    it('inner block should have height: 0px when open', () => {
       const wrapper = mount(<Collapse isOpen />);
       expect(wrapper.find('div').props().style.height,
     ).to.equal('0px');

--- a/test/components/Collapse.spec.js
+++ b/test/components/Collapse.spec.js
@@ -9,18 +9,18 @@ import Collapse from '../../src/components/collapse';
 
 describe('<Collapse />', () => {
   let requestAnimationFrameStub;
-  let setContentHeightSpy;
+  let setContentStylePropertySpy;
   let componentDidMountSpy;
   let componentWillReceivePropsSpy;
   beforeEach(() => {
     requestAnimationFrameStub = sinon.stub(util, 'requestAnimationFrame');
-    setContentHeightSpy = sinon.spy(Collapse.prototype, 'setContentProperty');
+    setContentStylePropertySpy = sinon.spy(Collapse.prototype, 'setContentStyleProperty');
     componentDidMountSpy = sinon.spy(Collapse.prototype, 'componentDidMount');
     componentWillReceivePropsSpy = sinon.spy(Collapse.prototype, 'componentWillReceiveProps');
   });
   afterEach(() => {
     requestAnimationFrameStub.restore();
-    setContentHeightSpy.restore();
+    setContentStylePropertySpy.restore();
     componentDidMountSpy.restore();
     componentWillReceivePropsSpy.restore();
   });
@@ -47,26 +47,22 @@ describe('<Collapse />', () => {
       mount(<Collapse isOpen><p>Content</p></Collapse>);
       sinon.assert.notCalled(requestAnimationFrameStub);
     });
-    it('should not requestAnimationFrame when collapsed', () => {
-      mount(<Collapse><p>Content</p></Collapse>);
-      sinon.assert.notCalled(requestAnimationFrameStub);
-    });
     it('calls componentDidMount and setContentHeight with args auto', () => {
       mount(<Collapse isOpen />);
       sinon.assert.called(Collapse.prototype.componentDidMount);
-      expect(Collapse.prototype.setContentProperty.calledOnce).to.equal(true);
+      expect(Collapse.prototype.setContentStyleProperty.calledOnce).to.equal(true);
     });
     it('calls componentWillReceiveProps when opened and calls setContentHeight', () => {
       const wrapper = mount(<Collapse />);
       wrapper.setProps({ isOpen: true });
       sinon.assert.called(Collapse.prototype.componentWillReceiveProps);
-      expect(Collapse.prototype.setContentProperty.calledWith('height', '0px')).to.equal(true);
+      expect(Collapse.prototype.setContentStyleProperty.calledWith('height', '0px')).to.equal(true);
     });
     it('calls componentWillReceiveProps when collapsed and calls setContentHeight', () => {
       const wrapper = mount(<Collapse isOpen />);
       wrapper.setProps({ isOpen: false });
       sinon.assert.called(Collapse.prototype.componentWillReceiveProps);
-      expect(Collapse.prototype.setContentProperty.calledWith('height', '0px')).to.equal(true);
+      expect(Collapse.prototype.setContentStyleProperty.calledWith('height', '0px')).to.equal(true);
     });
     it('calls requestAnimationFrame when collapsed', () => {
       const wrapper = mount(


### PR DESCRIPTION
- Using setTimeout(fn, 0) to ensure correct pixelheight is set before transition starts
- Tested in Internet Explorer, Firefox, Android, iOS