### PR TITLE
Fixing null content on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.0.2
+> Apr 5, 2017
+
+* :bug: **Bugfix** Checking if content is set before accessing content in requestAnimationFrame callback. This fixes a bug where `this.content` was null initially when navigating back to a page using react-css-collapse you had been to before.
+
 # 2.0.1
 > Apr 3, 2017
 

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -10,9 +10,11 @@ class Collapse extends Component {
 
       // on the next frame (as soon as removing transition has taken effect)
       util.requestAnimationFrame(() => {
-        // have the element set to the height of its inner content without transition
-        this.content.style.height = `${this.content.scrollHeight}px`;
-        this.content.style.transition = transition;
+        if (this.content) {
+          // have the element set to the height of its inner content without transition
+          this.content.style.height = `${this.content.scrollHeight}px`;
+          this.content.style.transition = transition;
+        }
       });
     }
   }


### PR DESCRIPTION
*  Fixed bug where `this.content` was null when navigating back to a page that had content in an expanded state