### PR TITLE
set overflow visible on mount when isOpen. closes #9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 3.0.1
+> Apr 30, 2017
+
+* :bug: **Bugfix** When `isOpen={true}`, set the `overflow: visible` after the component mounts to prevent cutting off content that may overflow outside the flow of `height: auto` (i.e. child content with `position: relative` and grandchildren with `position: absolute` may get cut off).
+
 # 3.0.0
 > Apr 7, 2017
 

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -1,33 +1,59 @@
 import React, { PropTypes, Component } from 'react';
 import util from '../util';
 
+const initialStyle = {
+  willChange: 'height',
+  height: '0px',
+  overflow: 'hidden',
+};
+
 class Collapse extends Component {
+  constructor() {
+    super();
+    this.onTransitionEnd = this.onTransitionEnd.bind(this);
+    this.setExpanded = this.setExpanded.bind(this);
+    this.setCollapsed = this.setCollapsed.bind(this);
+  }
+
   componentDidMount() {
     if (this.content && this.props.isOpen) {
-      this.setContentStyleProperty('height', 'auto');
+      this.setExpanded();
     }
   }
+
   componentWillReceiveProps(nextProps) {
-    if (this.content) {
-      // expand
-      if (!this.props.isOpen && nextProps.isOpen) {
-        // have the element transition to the height of its inner content
-        this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
-      }
-      // collapse
-      if (this.props.isOpen && !nextProps.isOpen) {
-        // explicitly set the element's height to its current pixel height, so we
-        // aren't transitioning out of 'auto'
-        this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
-        util.requestAnimationFrame(() => {
-          // "pausing" the JavaScript execution to let the rendering threads catch up
-          // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
-          setTimeout(() => {
-            this.setContentStyleProperty('height', '0px');
-            this.setContentStyleProperty('overflow', 'hidden');
-          }, 0);
-        });
-      }
+    if (!this.content) {
+      return;
+    }
+
+    // expand
+    if (!this.props.isOpen && nextProps.isOpen) {
+      // have the element transition to the height of its inner content
+      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
+    }
+
+    // collapse
+    if (this.props.isOpen && !nextProps.isOpen) {
+      // explicitly set the element's height to its current pixel height, so we
+      // aren't transitioning out of 'auto'
+      this.setContentStyleProperty('height', `${this.content.scrollHeight}px`);
+      util.requestAnimationFrame(() => {
+        // "pausing" the JavaScript execution to let the rendering threads catch up
+        // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
+        setTimeout(() => {
+          this.setCollapsed();
+        }, 0);
+      });
+    }
+  }
+
+  onTransitionEnd(e) {
+    if (this.props.isOpen) {
+      this.setExpanded();
+    }
+
+    if (this.props.onRest && e.target === this.content && e.propertyName === 'height') {
+      this.props.onRest();
     }
   }
 
@@ -35,25 +61,23 @@ class Collapse extends Component {
     this.content.style[property] = value;
   }
 
+  setCollapsed() {
+    this.setContentStyleProperty('height', '0px');
+    this.setContentStyleProperty('overflow', 'hidden');
+  }
+
+  setExpanded() {
+    this.setContentStyleProperty('height', 'auto');
+    this.setContentStyleProperty('overflow', 'visible');
+  }
+
   render() {
     return (
       <div
         ref={(el) => { this.content = el; }}
-        style={{
-          willChange: 'height',
-          height: '0px',
-          overflow: 'hidden',
-        }}
+        style={initialStyle}
         className={this.props.className}
-        onTransitionEnd={(e) => {
-          if (this.props.isOpen) {
-            this.setContentStyleProperty('height', 'auto');
-            this.setContentStyleProperty('overflow', 'visible');
-          }
-          if (this.props.onRest && e.target === this.content && e.propertyName === 'height') {
-            this.props.onRest();
-          }
-        }}
+        onTransitionEnd={this.onTransitionEnd}
       >
         {this.props.children && this.props.children}
       </div>

--- a/test/components/Collapse.spec.js
+++ b/test/components/Collapse.spec.js
@@ -9,17 +9,20 @@ import Collapse from '../../src/components/collapse';
 
 describe('<Collapse />', () => {
   let requestAnimationFrameStub;
+  let setExpandedSpy;
   let setContentStylePropertySpy;
   let componentDidMountSpy;
   let componentWillReceivePropsSpy;
   beforeEach(() => {
     requestAnimationFrameStub = sinon.stub(util, 'requestAnimationFrame');
+    setExpandedSpy = sinon.spy(Collapse.prototype, 'setExpanded');
     setContentStylePropertySpy = sinon.spy(Collapse.prototype, 'setContentStyleProperty');
     componentDidMountSpy = sinon.spy(Collapse.prototype, 'componentDidMount');
     componentWillReceivePropsSpy = sinon.spy(Collapse.prototype, 'componentWillReceiveProps');
   });
   afterEach(() => {
     requestAnimationFrameStub.restore();
+    setExpandedSpy.restore();
     setContentStylePropertySpy.restore();
     componentDidMountSpy.restore();
     componentWillReceivePropsSpy.restore();
@@ -50,7 +53,7 @@ describe('<Collapse />', () => {
     it('calls componentDidMount and setContentHeight with args auto', () => {
       mount(<Collapse isOpen />);
       sinon.assert.called(Collapse.prototype.componentDidMount);
-      expect(Collapse.prototype.setContentStyleProperty.calledOnce).to.equal(true);
+      expect(Collapse.prototype.setExpanded.calledOnce).to.equal(true);
     });
     it('calls componentWillReceiveProps when opened and calls setContentHeight', () => {
       const wrapper = mount(<Collapse />);


### PR DESCRIPTION
This PR sets the `overflow: visible` after mounting a component with `isOpen={true}`. I've added a few cleanup modifications as well.

Note: no changes to the API

- [x] move static css into a `const` instead of declaring a new style object on every render
- [x] use methods to set properties that exhibit the collapsed or expanded end state
- [x] bind methods in the constructor instead of during render method calls
- [x] use a short-circuit early return in `componentWillReceiveProps` to avoid nesting content in `if` block