### PR TITLE
	Accessing PropTypes from 'prop-types' package instead of main React package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 # 3.0.1
+> May 04, 2017
+
+* :bug: **Bugfix** 	Accessing PropTypes from 'prop-types' package instead of main React package. React.PropTypes will be deprecated in React 15.5
+
+# 3.0.1
 > Apr 30, 2017
 
 * :bug: **Bugfix** When `isOpen={true}`, set the `overflow: visible` after the component mounts to prevent cutting off content that may overflow outside the flow of `height: auto` (i.e. child content with `position: relative` and grandchildren with `position: absolute` may get cut off).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 3.0.1
+# 3.0.2
 > May 04, 2017
 
 * :bug: **Bugfix** 	Accessing PropTypes from 'prop-types' package instead of main React package. React.PropTypes will be deprecated in React 15.5

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-react": "^6.7.1",
     "jsdom": "^9.12.0",
     "mocha": "^3.1.2",
-    "mocha-teamcity-reporter": "^1.1.1",
+    "prop-types": "^15.5.8",
     "react": "15.4.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "15.4.2",

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import util from '../util';
 
 const initialStyle = {


### PR DESCRIPTION
- Accessing PropTypes from 'prop-types' package instead of main React package. React.PropTypes will be deprecated in React 15.5 (https://github.com/facebook/react/releases/tag/v15.5.0)
- Removed unused dependency (mocha-teamcity-reporter)