### PR TITLE
Add support for ARIA and data attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+> next
+* :tada: **Feature** Add support for ARIA and data attributes
+
 # 3.5.0
 > September 3, 2018
 * :nut_and_bolt: **New** Add transition prop

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ You can also specify a transition in line by using the `transition` prop.
 #### `onRest`: PropTypes.func
 Callback function for when your transition on `height` (specified in `className`) is finished. It can be used to trigger any function after transition is done.
 
+### ARIA and data attributes
+
+`Collapse` transfers `aria-` and `data-` attributes to the component's rendered DOM element. For example this can be used to set the `aria-hidden` attribute:
+
+```js
+<Collapse isOpen={isOpenState} aria-hidden={isOpenState ? 'false' : 'true'}>
+  <p>Paragraph of text</p>
+</Collapse>
+```
+
 ## Development and testing
 To run example covering all features, use `npm run storybook`.
 

--- a/src/components/Collapse.jsx
+++ b/src/components/Collapse.jsx
@@ -93,16 +93,18 @@ class Collapse extends PureComponent {
   }
 
   render() {
+    const { className, children, isOpen, transition, onRest, ...attrs } = this.props;
     return (
       <div
         ref={(el) => {
           this.content = el;
         }}
         style={this.state}
-        className={this.props.className}
+        className={className}
         onTransitionEnd={this.onTransitionEnd}
+        {...attrs}
       >
-        {this.props.children && this.props.children}
+        {children || false}
       </div>
     );
   }

--- a/src/components/Collapse.spec.js
+++ b/src/components/Collapse.spec.js
@@ -61,6 +61,14 @@ describe('<Collapse />', () => {
       const wrapper = shallow(makeWrapper({ isOpen: true }));
       expect(wrapper.prop('style').height).toEqual('0');
     });
+
+    it('should pass data- and aria-props as attributes', () => {
+      const wrapper = shallow(makeWrapper({
+        'aria-hidden': 'true', 'data-any-value': 'xyz',
+      }));
+      expect(wrapper.prop('aria-hidden')).toEqual('true');
+      expect(wrapper.prop('data-any-value')).toEqual('xyz');
+    });
   });
 
   describe('Component', () => {


### PR DESCRIPTION
The change would add support for passing on DOM attributes as component properties. This solves the use case of setting the `aria-hidden` attribute (see example code in README.md).

Adding this behavior makes the transition from [react-collapse](https://www.npmjs.com/package/react-collapse) easier.